### PR TITLE
Change exception handling, change class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can find the arguments defined at the top of [cli.py](./sunzip/cli.py)
 ```python=
 import sunzip
 
-f = sunzip.sunzip("archive.zip")
+f = sunzip.Sunzip("archive.zip")
 ```
 
 
@@ -134,7 +134,7 @@ If there is no setting, the default value will be used.
 ```python=
 import sunzip
 
-f = sunzip.sunzip("archive.zip")
+f = sunzip.Sunzip("archive.zip")
 
 f.extract()
 ```

--- a/sunzip/__init__.py
+++ b/sunzip/__init__.py
@@ -16,7 +16,7 @@ MAX_FILESIZE_USAGE = 134217728
 MAX_THRESHOLD = 100
 
 
-class sunzip():
+class Sunzip():
 
     # details finer than debug
     LOG_TRACE=3
@@ -177,9 +177,9 @@ class sunzip():
 
         # Defense Layer 3 - Filetype-specific mitigations.
         if (status is True):
-            self.log_debug(sunzip.LOG_INFO, "All rules have checked completely. Start to unzipping.")
+            self.log_debug(Sunzip.LOG_INFO, "All rules have checked completely. Start to unzipping.")
             self.zip_file.extractall(path=self.output_dir)
-            self.log_debug(sunzip.LOG_INFO, "Extraction complete.")
+            self.log_debug(Sunzip.LOG_INFO, "Extraction complete.")
 
 
 class ZipFilePitfall(Exception):

--- a/sunzip/__init__.py
+++ b/sunzip/__init__.py
@@ -144,46 +144,31 @@ class sunzip():
 
         # Check if the file format is expected for context.
 
-        try:
-            if(self.check_is_zipfile()):
-                status = True
-            else:
-                raise ZipFilePitfall("File type is not zip format.")
-        except Exception as e:
-            print(e)
-            sys.exit(0)
+        
+        if(self.check_is_zipfile()):
+            status = True
+        else:
+            raise ZipFilePitfall("File type is not zip format.")
 
         # Check if it's a nested zip file.
-        try:
-            if(self.check_is_nested()):
-                status = True
-            else:
-                raise ZipFilePitfall("Zip file contains nested zip file.")
-        except Exception as e:
-            print(e)
-            sys.exit(0)
+        if(self.check_is_nested()):
+            status = True
+        else:
+            raise ZipFilePitfall("Zip file contains nested zip file.")
 
         # Check if the compression ratio is greater than threshold.
-        try:
-            if(self.get_compression_ratio() <= self.max_threshold):
-                status = True
-            else:
-                raise ZipFilePitfall(
-                    "Compression ratio is greater than threshold.")
-        except Exception as e:
-            print(e)
-            sys.exit(0)
+        if(self.get_compression_ratio() <= self.max_threshold):
+            status = True
+        else:
+            raise ZipFilePitfall(
+                "Compression ratio is greater than threshold.")
 
         # Check if the upload file size exceeds the maximum limit.
-        try:
-            if(self.get_zip_file_size() <= self.max_filesize_usage):
-                status = True
-            else:
-                raise ZipFilePitfall(
-                    "File size exceeds the maximum limit.")
-        except Exception as e:
-            print(e)
-            sys.exit(0)
+        if(self.get_zip_file_size() <= self.max_filesize_usage):
+            status = True
+        else:
+            raise ZipFilePitfall(
+                "File size exceeds the maximum limit.")
 
         # Defense Layer 2 - Limit the number of resources available to a
         # process and its child process.

--- a/sunzip/__init__.py
+++ b/sunzip/__init__.py
@@ -17,15 +17,14 @@ MAX_THRESHOLD = 100
 
 
 class Sunzip():
-
     # details finer than debug
-    LOG_TRACE=3
+    LOG_TRACE = 3
     # messages useful for debugging
-    LOG_DEBUG=2
+    LOG_DEBUG = 2
     # messages related to the progress of the tool
-    LOG_INFO=1
+    LOG_INFO = 1
     # no messages
-    LOG_NONE=0
+    LOG_NONE = 0
 
     def __init__(self, path, method=None):
         """
@@ -49,7 +48,7 @@ class Sunzip():
         # Check if it's a real zip file.
         # Return True when it is a real zip file
 
-        if (zipfile.is_zipfile(self.path)):
+        if zipfile.is_zipfile(self.path):
             return True
         else:
             raise ZipFilePitfall("File does not match to zip format.")
@@ -58,7 +57,7 @@ class Sunzip():
         # Check if it's a nested zip file. (i.e. 42.zip)
         # Return True when there is no nested zip file.
         for f in self.zip_file.namelist():
-            if(os.path.splitext(f)[1] == ".zip"):
+            if os.path.splitext(f)[1] == ".zip":
                 raise ZipFilePitfall("Found a nested compressed file.")
             else:
                 return True
@@ -144,27 +143,26 @@ class Sunzip():
 
         # Check if the file format is expected for context.
 
-        
-        if(self.check_is_zipfile()):
+        if self.check_is_zipfile():
             status = True
         else:
             raise ZipFilePitfall("File type is not zip format.")
 
         # Check if it's a nested zip file.
-        if(self.check_is_nested()):
+        if self.check_is_nested():
             status = True
         else:
             raise ZipFilePitfall("Zip file contains nested zip file.")
 
         # Check if the compression ratio is greater than threshold.
-        if(self.get_compression_ratio() <= self.max_threshold):
+        if self.get_compression_ratio() <= self.max_threshold:
             status = True
         else:
             raise ZipFilePitfall(
                 "Compression ratio is greater than threshold.")
 
         # Check if the upload file size exceeds the maximum limit.
-        if(self.get_zip_file_size() <= self.max_filesize_usage):
+        if self.get_zip_file_size() <= self.max_filesize_usage:
             status = True
         else:
             raise ZipFilePitfall(
@@ -176,7 +174,7 @@ class Sunzip():
         self._limit_source()
 
         # Defense Layer 3 - Filetype-specific mitigations.
-        if (status is True):
+        if status is True:
             self.log_debug(Sunzip.LOG_INFO, "All rules have checked completely. Start to unzipping.")
             self.zip_file.extractall(path=self.output_dir)
             self.log_debug(Sunzip.LOG_INFO, "Extraction complete.")

--- a/sunzip/cli.py
+++ b/sunzip/cli.py
@@ -41,7 +41,7 @@ def main():
     )
     args = parser.parse_args()
 
-    zip_archive = sunzip.sunzip(args.zip_file)
+    zip_archive = sunzip.Sunzip(args.zip_file)
 
     if args.max_compression_ratio:
         zip_archive.threshold = args.max_compression_ratio
@@ -54,7 +54,7 @@ def main():
     if args.output_dir:
         zip_archive.output_dir = args.output_dir
     if args.verbose:
-        zip_archive.debug = sunzip.sunzip.LOG_TRACE
+        zip_archive.debug = sunzip.Sunzip.LOG_TRACE
 
     try:
         zip_archive.extract()

--- a/sunzip/cli.py
+++ b/sunzip/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import sunzip
+import sys
 
 def main():
     parser = argparse.ArgumentParser()
@@ -55,4 +56,8 @@ def main():
     if args.verbose:
         zip_archive.debug = sunzip.sunzip.LOG_TRACE
 
-    zip_archive.extract()
+    try:
+        zip_archive.extract()
+    except Exception as e:
+        print(e)
+        sys.exit(1)

--- a/sunzip/cli.py
+++ b/sunzip/cli.py
@@ -2,6 +2,7 @@ import argparse
 import sunzip
 import sys
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("zip_file", help="the zip archive to unzip safely")
@@ -46,11 +47,11 @@ def main():
     if args.max_compression_ratio:
         zip_archive.threshold = args.max_compression_ratio
     if args.max_cpu_seconds:
-        zip_archive.cpu =  args.max_cpu_seconds
+        zip_archive.cpu = args.max_cpu_seconds
     if args.max_memory_bytes:
         zip_archive.memory = args.max_memory_bytes
     if args.max_disk_space_bytes:
-        zip_archive.filesize  = args.max_disk_space_bytes
+        zip_archive.filesize = args.max_disk_space_bytes
     if args.output_dir:
         zip_archive.output_dir = args.output_dir
     if args.verbose:


### PR DESCRIPTION
Let users of the library catch and handle exception themselves instead of bailing.
Let cli catch and exit 1 to signify error
Change class name to be capitalized to make distinct from modules and variables